### PR TITLE
Save the key in `.env.local`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 <h1 align="center">Create, share and analyse your forms</h1>
 
-
 <p align="center">
   <img alt="Github Checks" src="https://badgen.net/github/checks/xataio/xataform/main"/>
   <a href="https://github.com/xataio/xataform/blob/main/LICENSE">
@@ -34,7 +33,7 @@ In order to run the project, you will need two accounts (free):
 
 1. Install the dependencies: `pnpm install`
 1. Initialize your database: `pnpm xata:init`
-1. Add Clerk keys in `.env`: https://clerk.com/docs/nextjs/set-environment-keys
+1. Add Clerk keys in `.env.local`: https://clerk.com/docs/nextjs/set-environment-keys
 1. Start the dev server: `pnpm dev`
 
 ## Architecture
@@ -52,6 +51,3 @@ Everything is defined in `/server`:
 ### Pages
 
 A classic Next.js application pattern, every file is a page.
-
-
-

--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -19,7 +19,7 @@ async function main() {
   // Read dotenv
   let dotEnv = "";
   try {
-    dotEnv = await readFile(".env", "utf-8");
+    dotEnv = await readFile(".env.local", "utf-8");
   } catch {}
 
   // Xata token
@@ -44,11 +44,11 @@ async function main() {
     if (
       (await confirm({
         message:
-          "Do you want to store the key in .env file? (required to have project working)",
+          "Do you want to store the key in .env.local file? (required to have project working)",
       })) === true
     ) {
       writeFile(
-        ".env",
+        ".env.local",
         dotEnv.trim() +
           `${
             dotEnv.trim().split("\n").length > 1 ? "\n\n" : ""


### PR DESCRIPTION
To follow Clerk documentation and avoid confusion, let's store the secret key in `.env.local` instead of `.env`