### PR TITLE
Improve form mobile layout

### DIFF
--- a/components/Form.tsx
+++ b/components/Form.tsx
@@ -54,7 +54,7 @@ export function Form({ questions, onSubmit, ending }: FormProps) {
           <div
             className={clsx(
               "grid grid-cols-header p-10",
-              !question.illustration && "w-full p-28"
+              !question.illustration && "w-full sm:p-28"
             )}
           >
             {/* Question number */}
@@ -181,7 +181,7 @@ export function Form({ questions, onSubmit, ending }: FormProps) {
         style={{ top: `calc(100vh * -${slideNumber - 1})` }}
         className={clsx(
           "relative transition-all duration-700",
-          "h-screen",
+          "h-screen w-screen text-center",
           "flex flex-col items-center justify-center gap-4",
           "bg-indigo-50"
         )}
@@ -198,8 +198,11 @@ export function Form({ questions, onSubmit, ending }: FormProps) {
         <>
           <div
             className={clsx(
-              "absolute bottom-3 -translate-x-full text-sm text-indigo-600",
-              "transition-all duration-200"
+              "absolute bottom-3 px-1 text-sm text-indigo-600",
+              "transition-all duration-200",
+              slideNumber > questions.length / 2
+                ? "-translate-x-full"
+                : "-translate-x-1/2"
             )}
             style={{
               left: `calc(${(slideNumber / questions.length) * 100}vw)`,

--- a/components/Question/AnswerStatement.tsx
+++ b/components/Question/AnswerStatement.tsx
@@ -20,7 +20,7 @@ function AnswerStatement(props: AnswerProps<"statement">) {
         <Button type="submit">
           {props.buttonText || (props.isLastQuestion ? "Submit" : "Continue")}
         </Button>
-        <div className="text-xs">
+        <div className="hidden text-xs sm:block">
           press <b>Enter</b>↵
         </div>
       </div>

--- a/components/Question/AnswerWrapper.tsx
+++ b/components/Question/AnswerWrapper.tsx
@@ -57,7 +57,7 @@ export function AnswerWrapper(props: {
           <Button type="submit">
             {props.isLastAnswer ? "Submit" : "OK ✓"}
           </Button>
-          <div className="text-xs">
+          <div className="hidden text-xs sm:block">
             press <b>{props.keyToSubmit ?? "Enter ↵"}</b>
           </div>
         </div>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1761469/236253171-ff5a5ebe-6412-4a3b-9e05-4a19116144d8.png)

After:
![image](https://user-images.githubusercontent.com/1761469/236253093-8e8a81c2-755b-494c-9b9a-f0af0068e38a.png)

Note:

This is definitly not perfect (please don't check the matrix question on mobile 🙃), just improving and going in the correct direction 😉 